### PR TITLE
[Feat] rgb 비트 연산 구현

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ NAME = cub3D
 MLX_DIR = ./mlx
 libft = ./libft/libft.a
 
-SRCS = main.c operate.c draw.c parse.c parse_cub.c parse_utils.c
+SRCS = main.c operate.c draw.c parse.c parse_cub.c parse_color.c parse_utils.c
 SRCS := $(addprefix srcs/, $(SRCS))
 GNL_SRCS	= gnl/get_next_line.c gnl/get_next_line_utils.c
 

--- a/srcs/cub3d.h
+++ b/srcs/cub3d.h
@@ -109,5 +109,6 @@ void	free_strs(char **strs);
 int		is_empty_line(char *line);
 void	parse(char *av, t_cub *c);
 void	parse_cub(int fd, t_cub *c);
+int 	parse_color(char *value);
 
 #endif

--- a/srcs/parse_color.c
+++ b/srcs/parse_color.c
@@ -1,0 +1,40 @@
+#include "cub3d.h"
+
+static int	calc_color(int color, int rgb)
+{
+	if (rgb < 0 || rgb > 255)
+		return (-1);
+	color <<= 8;
+	return (color |= rgb);
+}
+
+int parse_color(char *value)
+{
+	char	**split;
+	int		color;
+	int		i;
+
+	i = -1;
+	color = 0;
+	split = ft_split(value, ',');
+	if (!split)
+	{
+		// free(line); // 프리할 걸 다 받아올 수 없어서
+		err_exit("Malloc failed.", NULL);
+		// return (-1); // 이렇게 아래와 같이 할까 생각중
+	}
+	while (split[++i])
+	{
+		color = calc_color(color, ft_atoi(split[i]));
+		if (color < 0)
+			break ;
+	}
+	if (color < 0 || i > 3)
+	{
+		free_strs(split);
+		err_exit("Invalid rgb color.", NULL);
+		// return (-1); 
+		// 이거 던져서 set_cub_content에서 받아서 0 리턴해서 set_cub에서 한꺼번에 처리할 방법 생각중
+	}
+	return (color);
+}

--- a/srcs/parse_cub.c
+++ b/srcs/parse_cub.c
@@ -3,7 +3,8 @@
 
 static int set_cub_content(char *key, char *value, unsigned int len, t_cub *c)
 {
-	 // ft_strdup에 실패할 경우도 생각해봐야할 것 같아요 😭
+	 // ft_strdup, parse_color에 실패할 경우도 생각해봐야할 것 같아요 😭
+	 // 0으로 반환해야 무한루프를 안 돌 것 같은데
 	if (ft_strncmp(key, "NO", len) == 0 && c->no == NULL)
 		c->no = ft_strdup(value);
 	else if (ft_strncmp(key, "SO", len) == 0 && c->so == NULL)
@@ -13,9 +14,9 @@ static int set_cub_content(char *key, char *value, unsigned int len, t_cub *c)
 	else if (ft_strncmp(key, "EA", len) == 0 && c->ea == NULL)
 		c->ea = ft_strdup(value);
 	else if (ft_strncmp(key, "F", len) == 0 && c->fl == -1)
-		c->fl = 1; // 임시
+		c->fl = parse_color(value);
 	else if (ft_strncmp(key, "C", len) == 0 && c->ce == -1)
-		c->ce = 1; // 임시
+		c->ce = parse_color(value);
 	else
 		return (0);
 	return (1);
@@ -23,11 +24,12 @@ static int set_cub_content(char *key, char *value, unsigned int len, t_cub *c)
 
 static void	set_cub(char ***split, char **line, t_cub *c)
 {
+	
 	if (!set_cub_content((*split)[0], (*split)[1], ft_strlen((*split)[0]), c))
 	{
 		free(*line);
 		free_strs(*split);
-		err_exit("Malloc failed.", NULL);
+		err_exit("Failed to save Map contents", NULL);
 	}
 	else
 	{
@@ -60,8 +62,10 @@ static void	check_cub(int fd, t_cub *c)
 
 void	parse_cub(int fd, t_cub *c)
 {
-	do {
+	check_cub(fd, c);
+	while (c->no == NULL || c->so == NULL || c->we == NULL\
+		|| c->ea == NULL || c->fl == -1 || c->ce == -1)
+	{
 		check_cub(fd, c);
-	} while (c->no == NULL || c->so == NULL || c->we == NULL\
-			|| c->ea == NULL || c->fl == -1 || c->ce == -1);
+	}
 }


### PR DESCRIPTION
## 개요
- rgb 비트 연산 구현

## 작업사항
- rgb 비트 연산 함수 추가
  - int 4바이트 → 1바이트: 투명도, 1바이트: r, 1바이트: g, 1바이트: b
  - atoi로 숫자 변환 후, 비트 연산으로 저장
- do while 문은 노미넷에 걸린다고 합니다🥲 수정해쓰요...
- 이밖에 주석 처리된 사항은  추후 수정해서 고치도록 하겠습니다. (일단 돌아가기는 하니까!)
- 이제 맵 파싱을 먼저 구현하려구요...!!

## 변경로직
- 내용을 적어주세요.
