### PR TITLE
[Fix] 잘못된 맵 파싱 중 abort 오류 수정

### DIFF
--- a/srcs/free.c
+++ b/srcs/free.c
@@ -26,8 +26,6 @@ void	free_double_int(int **ptr)
 
 void	free_cub(t_cub *cub)
 {
-	if (!cub)
-		return ;
 	if (cub->no)
 		free(cub->no);
 	if (cub->so)
@@ -36,5 +34,6 @@ void	free_cub(t_cub *cub)
 		free(cub->we);
 	if (cub->ea)
 		free(cub->ea);
-	free_double_char(cub->map);
+	if (cub->map)
+		free_double_char(cub->map);
 }

--- a/srcs/init.c
+++ b/srcs/init.c
@@ -7,6 +7,7 @@ void	init_cub(t_cub *c)
 	c->so = NULL;
 	c->ea = NULL;
 	c->we = NULL;
+	c->map = NULL;
 	c->fl = UNDEF;
 	c->ce = UNDEF;
 	c->h = 0;


### PR DESCRIPTION
## 개요
- 잘못된 맵 파싱 중 abort 오류 수정

## 작업사항
- map을 초기화 안 해주고, 맵 오류가 났을 때, cub 구조체를 프리해줘서 생기는 문제
- `init_cub`에 `map=NULL` 초기화 추가
- `cub->map`이 있을때만 프리

## 변경로직
- 내용을 적어주세요.
