### PR TITLE
[Fix] 맵 넓이를 1 많게 세서 빵꾸난 줄 모르는 문제 해결

### DIFF
--- a/bonus/parse_map_bonus.c
+++ b/bonus/parse_map_bonus.c
@@ -69,7 +69,7 @@ static int	check_element(char *line, int *flag, t_game *g)
 		if (!gnl_strchr("210 \n", line[x]))
 			return (FAIL);
 	}
-	if (x > g->cub->w)
+	if (--x > g->cub->w)
 		g->cub->w = x;
 	return (SUCCESS);
 }

--- a/srcs/parse_map.c
+++ b/srcs/parse_map.c
@@ -69,7 +69,7 @@ static int	check_element(char *line, int *flag, t_game *g)
 		if (!gnl_strchr("10 \n", line[x]))
 			return (FAIL);
 	}
-	if (x > g->cub->w)
+	if (--x > g->cub->w)
 		g->cub->w = x;
 	return (SUCCESS);
 }


### PR DESCRIPTION
## 개요
- 맵의 오른쪽 끝에서 빵꾸가 났을 때, 에러를 잡아주지 못하는 문제 발견!
- 원인은 맵 넓이를 1 많게 세서... 😭

## 작업사항
- `cub->w`에 할당할 때 `--w` 해주기

# 변경로직
- ..
