### PR TITLE
[Fix] 컬러 파싱 수정

### DIFF
--- a/bonus/parse_color_bonus.c
+++ b/bonus/parse_color_bonus.c
@@ -1,5 +1,4 @@
 #include "cub3d_bonus.h"
-#include <stdio.h>
 
 static int	calc_color(int color, int rgb)
 {

--- a/bonus/parse_color_bonus.c
+++ b/bonus/parse_color_bonus.c
@@ -1,4 +1,5 @@
 #include "cub3d_bonus.h"
+#include <stdio.h>
 
 static int	calc_color(int color, int rgb)
 {
@@ -6,6 +7,19 @@ static int	calc_color(int color, int rgb)
 		return (-1);
 	color <<= 8;
 	return (color |= rgb);
+}
+
+static int	check_isdigit(char *str)
+{
+	int	i;
+	
+	i = -1;
+	while (str[++i])
+	{
+		if (!ft_isdigit(str[i]))
+			return (FAIL);
+	}
+	return (SUCCESS);
 }
 
 void	set_color(int *texture, char *value)
@@ -21,12 +35,14 @@ void	set_color(int *texture, char *value)
 		err_exit(0);
 	while (split[++i])
 	{
+		if (i < 3 && check_isdigit(split[i]))
+			break ;
 		color = calc_color(color, ft_atoi(split[i]));
 		if (color < 0)
 			break ;
 	}
 	free_double_char(split);
-	if (color < 0 || i > 3)
+	if (color < 0 || i != 2)
 		err_exit("Invalid color.");
 	*texture = color;
 }

--- a/srcs/parse_color.c
+++ b/srcs/parse_color.c
@@ -1,5 +1,4 @@
 #include "cub3d.h"
-#include <stdio.h>
 
 static int	calc_color(int color, int rgb)
 {

--- a/srcs/parse_color.c
+++ b/srcs/parse_color.c
@@ -1,4 +1,5 @@
 #include "cub3d.h"
+#include <stdio.h>
 
 static int	calc_color(int color, int rgb)
 {
@@ -6,6 +7,19 @@ static int	calc_color(int color, int rgb)
 		return (-1);
 	color <<= 8;
 	return (color |= rgb);
+}
+
+static int	check_isdigit(char *str)
+{
+	int	i;
+	
+	i = -1;
+	while (str[++i])
+	{
+		if (!ft_isdigit(str[i]))
+			return (FAIL);
+	}
+	return (SUCCESS);
 }
 
 void	set_color(int *texture, char *value)
@@ -21,12 +35,14 @@ void	set_color(int *texture, char *value)
 		err_exit(0);
 	while (split[++i])
 	{
+		if (i < 3 && check_isdigit(split[i]))
+			break ;
 		color = calc_color(color, ft_atoi(split[i]));
 		if (color < 0)
 			break ;
 	}
 	free_double_char(split);
-	if (color < 0 || i > 3)
+	if (color < 0 || i != 2)
 		err_exit("Invalid color.");
 	*texture = color;
 }


### PR DESCRIPTION
## 개요
- `,` 기준으로 `split`으로 자르고 `atoi`로 변환하는 과정에서,
- 인자가 숫자인지 판별하지 못하고 atoi 냅다 해버려서 생기는 문제

## 작업사항
- `check_isdigit()`으로 숫자인지 판별하는 함수 추가 

## 변경로직
- 내용을 적어주세요.
