### PR TITLE
[Fix] 미니맵 에러 처리 추가 및 공백은 배경이 보이게 하기

### DIFF
--- a/bonus/draw_minimap_bonus.c
+++ b/bonus/draw_minimap_bonus.c
@@ -6,14 +6,12 @@ static void	set_minimap(t_mlx *m, int y, int x, char op)
 	int i;
 	int j;
 
-	if (op == '2')
-		color = 0x00fd00;
+	if (op == ' ')
+		return ;
 	if (op == '1')
 		color = 0X000000;
 	if (op == '0')
 		color = 0Xffffff;
-	if (op == ' ')
-		color = 0X727272;
 	if (op == 'p')
 		color = 0xff0000;
 	i = -1;

--- a/bonus/parse_bonus.c
+++ b/bonus/parse_bonus.c
@@ -16,6 +16,12 @@ static void	check_file(char *av, int *fd)
 		err_exit("Open map failed.");
 }
 
+static void	check_minimap(t_game *g)
+{
+	if ((g->cub->h * 5 > WIN_Y) || (g->cub->w * 5 > WIN_X))
+		err_exit("Map too big.");
+}
+
 void	parse(char *av, t_game *g)
 {
 	int		fd;
@@ -24,4 +30,5 @@ void	parse(char *av, t_game *g)
 	parse_cub(fd, g->cub);
 	parse_map(fd, g);
 	close(fd);
+	check_minimap(g);
 }

--- a/bonus/parse_map_bonus.c
+++ b/bonus/parse_map_bonus.c
@@ -8,7 +8,7 @@ static void	check_map_closed(int y, char **map, t_cub *c)
 	x = -1;
 	while (++x < c->w)
 	{
-		if ((map[y][x] == '0' || map[y][x] == '2') && (\
+		if (map[y][x] == '0' && (\
 			y == 0 || y == c->h - 1 || x == 0 || x == c->w - 1 \
 			|| map[y - 1][x] == ' ' || map[y + 1][x] == ' ' \
 			|| map[y][x - 1] == ' ' || map[y][x + 1] == ' '))
@@ -67,7 +67,7 @@ static int	check_element(char *line, int *flag, t_game *g)
 			line[x] = '0';
 			continue ;
 		}
-		if (!gnl_strchr("210 \n", line[x]))
+		if (!gnl_strchr("10 \n", line[x]))
 			return (FAIL);
 	}
 	if (--x > g->cub->w)


### PR DESCRIPTION
## 개요
- 미니맵 에러 처리 추가 및 공백은 배경이 보이게 하기

## 작업사항
- 맵이 윈도우 사이즈보다 클 경우 미니맵 그리다 세그폴트나는 문제 수정
- 공백일 때 배경으로 보이게 하기
- 보너스 안해서 2 체크하는 거 빼기
- 휴🤣

## 변경로직
- ..
